### PR TITLE
fix: long-term key exposure and ensure zeroization after use

### DIFF
--- a/cmd/sgx/go.mod
+++ b/cmd/sgx/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/venture23-aleo/aleo-utils-go v1.0.0
 )
 
+replace github.com/venture23-aleo/aleo-utils-go => ../..
+
 require (
 	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
 	github.com/tetratelabs/wazero v1.8.1 // indirect

--- a/cmd/sgx/sgx.go
+++ b/cmd/sgx/sgx.go
@@ -71,7 +71,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	signature, err := s.Sign("APrivateKey1zkpEem71u7U75h5VodKNgyR37aGJBj4ZTgagCHm3qsuz5PU", []byte(hashedReport))
+	signature, err := s.Sign([]byte("APrivateKey1zkpEem71u7U75h5VodKNgyR37aGJBj4ZTgagCHm3qsuz5PU"), []byte(hashedReport))
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -93,5 +93,5 @@ func main() {
 	b.WriteString(fmt.Sprintf("Hashed report = \"%s\"\n", hashedReport))
 	b.WriteString(fmt.Sprintf("Signature = \"%s\"\n", signature))
 
-	os.WriteFile("output.txt", []byte(b.String()), 0666)
+	os.WriteFile("output.txt", []byte(b.String()), 0o666)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -57,7 +57,7 @@ func Example() {
 	log.Println("Signature:", signature)
 	log.Println("Address:", address)
 	log.Println("Poseidon8 hash:", hashedMessage)
-	log.Println("Private key:", privKey)
+	log.Println("Private key:", string(privKey))
 
 	// Output:
 }

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -44,8 +44,8 @@ func TestAleoWrapper_NewPrivateKey(t *testing.T) {
 		t.Fatalf("AleoWrapper.NewPrivateKey() error = %v\n", err)
 		return
 	}
-	if gotKey == "" {
-		t.Errorf("AleoWrapper.NewPrivateKey() gotKey = %v, want not empty\n", gotKey)
+	if len(gotKey) == 0 {
+		t.Errorf("AleoWrapper.NewPrivateKey() gotKey is empty, want not empty\n")
 	}
 	if gotAddress == "" {
 		t.Errorf("AleoWrapper.NewPrivateKey() gotAddress = %v, want not empty\n", gotAddress)
@@ -122,7 +122,7 @@ func TestAleoWrapper_FormatMessage(t *testing.T) {
 
 func TestAleoWrapper_Sign(t *testing.T) {
 	type args struct {
-		key     string
+		key     []byte
 		message []byte
 	}
 
@@ -150,7 +150,7 @@ func TestAleoWrapper_Sign(t *testing.T) {
 		{
 			name: "empty key",
 			args: args{
-				key:     "",
+				key:     []byte{},
 				message: []byte(""),
 			},
 			wantErr: true,
@@ -158,7 +158,7 @@ func TestAleoWrapper_Sign(t *testing.T) {
 		{
 			name: "invalid key",
 			args: args{
-				key:     "12345678901234567890123456789012345678901234567890123456789",
+				key:     []byte("12345678901234567890123456789012345678901234567890123456789"),
 				message: []byte(""),
 			},
 			wantErr: true,


### PR DESCRIPTION
Address long-term key exposure by modifying the handling of private keys to use byte slices instead of strings. Implement zeroization of private key data in memory after use to enhance security. Update documentation and examples accordingly.